### PR TITLE
修改读取属性文件方法，防止找不到文件

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -109,7 +109,7 @@ android {
 //    }
 }
 
-File propFile = file('signing.properties');
+def propFile = project.rootProject.file('signing.properties');
 if (propFile.exists()) {
     def Properties props = new Properties()
     props.load(new FileInputStream(propFile))


### PR DESCRIPTION
在有的机器上不加上项目根目录会找不到文件
